### PR TITLE
Optimization of the algorithm for question-set selection

### DIFF
--- a/ScrumTrainer/BusinessLogic/JsonQuestionSetProvider.cs
+++ b/ScrumTrainer/BusinessLogic/JsonQuestionSetProvider.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using ScrumTrainer.Extensions;
 using ScrumTrainer.Models;
 
 namespace ScrumTrainer.BusinessLogic;
@@ -16,9 +17,7 @@ public class JsonQuestionSetProvider : IQuestionSetProvider
                 ?? throw new ApplicationException("No questions found in JSON file");
 
             var random = new Random();
-            return [.. allQuestions
-                .OrderBy(x => random.Next())
-                .Take(questionsCount)];  
+            return [.. allQuestions.TakeShuffled(questionsCount)];
         }
         catch (Exception ex)
         {

--- a/ScrumTrainer/Extensions/EnumerableExtensions.cs
+++ b/ScrumTrainer/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,30 @@
+namespace ScrumTrainer.Extensions;
+
+public static class EnumerableExtensions
+{
+    public static IEnumerable<T> TakeShuffled<T>(
+        this IEnumerable<T> source,
+        int numElementsToTake,
+        Random? random = null)
+    {
+        if (source == null || numElementsToTake < 0)
+            return default!;
+
+        random ??= new Random();
+
+        var list = source.ToList();
+        int n = list.Count;
+
+        if (numElementsToTake > n)
+            numElementsToTake = n; // We can't take more elements than the source's length
+
+        // Partial Fisher–Yates
+        for (int i = 0; i < numElementsToTake; i++)
+        {
+            int j = random.Next(i, n);
+            (list[i], list[j]) = (list[j], list[i]); // Swap
+        }
+
+        return list.Take(numElementsToTake);
+    }
+}


### PR DESCRIPTION
Before this change, the algorithm for shuffle and selection of the question-set had an efficiency of O(n log n), being 'n' the length of the collection of all questions.

After this change, this algorithm is optimized using a partial Fisher-Yates algorithm, which brings an efficiency of O(k) or, in the worse case, of O(n), being 'k' the number of the desired length of the question-set, and 'n' the length of the collection of all questions.