### PR TITLE
Display right answer rate when finish

### DIFF
--- a/ScrumTrainer/BusinessLogic/Quiz.cs
+++ b/ScrumTrainer/BusinessLogic/Quiz.cs
@@ -43,6 +43,8 @@ public sealed class Quiz: IQuizStatusProvider, IDisposable
         get => Questions?.Count( q => q.IsRight ) ?? 0;
     }
 
+    public double RightRate { get => (double) QuestionsRightCount / QuestionsCount; }
+
     public Quiz(int questionsCount, int timeLimitInSeconds)
         :this(questionsCount, timeLimitInSeconds, new JsonQuestionSetProvider(), null)
     {

--- a/ScrumTrainer/Components/QuizViewer.razor
+++ b/ScrumTrainer/Components/QuizViewer.razor
@@ -41,7 +41,7 @@
     {
         <div class="quiz-info quiz-completed">
             <h4>Quiz completed!</h4>
-            <p class="quiz-results"><strong>Right Answers:</strong> @Quiz.QuestionsRightCount / @Quiz.QuestionsCount</p>
+            <p class="quiz-results"><strong>Right Answers:</strong> @Quiz.QuestionsRightCount / @Quiz.QuestionsCount (@Quiz.RightRate.ToString(@"P0"))</p>
             <div><strong>Question:</strong> @(Quiz.CurrentQuestionIndex + 1) / @Quiz.QuestionsCount</div>
         </div>
     }

--- a/ScrumTrainerTests/QuizTests.cs
+++ b/ScrumTrainerTests/QuizTests.cs
@@ -514,4 +514,56 @@ public class QuizTests
             testModelRepository.ModelSet.Should().NotBeEmpty();
         }
     }
+
+    public class RightRate
+    {
+        [Fact]
+        public void NotAllAnswersAreRight_RightRate_IsNotZero()
+        {
+            var quiz = new Quiz(5, 10, CreateQuestionSetProvider());
+            quiz.StartQuiz();
+            foreach(var question in quiz.Questions)
+            {
+                question.SelectSingleAnswer(0);
+            }
+            quiz.Questions.ElementAt(0).SelectSingleAnswer(1);
+            quiz.FinishQuiz();
+
+            var rate = quiz.RightRate;
+
+            rate.Should().BeGreaterThan(0d);
+        }
+
+        [Fact]
+        public void AllAnswersAreRight_RightRate_IsOne()
+        {
+            var quiz = new Quiz(5, 10, CreateQuestionSetProvider());
+            quiz.StartQuiz();
+            foreach(var question in quiz.Questions)
+            {
+                question.SelectSingleAnswer(0);
+            }
+            quiz.FinishQuiz();
+
+            var rate = quiz.RightRate;
+
+            rate.Should().Be(1d);
+        }
+
+        [Fact]
+        public void AllAnswersAreWrong_RightRate_IsZero()
+        {
+            var quiz = new Quiz(5, 10, CreateQuestionSetProvider());
+            quiz.StartQuiz();
+            foreach(var question in quiz.Questions)
+            {
+                question.SelectSingleAnswer(1);
+            }
+            quiz.FinishQuiz();
+
+            var rate = quiz.RightRate;
+
+            rate.Should().Be(0d);
+        }
+    }
 }


### PR DESCRIPTION
Before this change, it displayed the number of right answers and the total of questions only.

After this change, a rate as percentage is also displayed, in order to see the score of the quiz better.