### PR TITLE
Add SessionId to QuizResult and update anonymous user handling

### DIFF
--- a/ScrumTrainer/BusinessLogic/Quiz.cs
+++ b/ScrumTrainer/BusinessLogic/Quiz.cs
@@ -29,6 +29,8 @@ public sealed class Quiz: IQuizStatusProvider, IDisposable
     public bool IsResetDisabled { get => !IsStarted && !IsCompleted; }
 
     public ApplicationUser User { get; set; } = default!;
+    
+    public string SessionId { get; set; } = default!;
 
     private readonly Timer _timer;
 
@@ -66,6 +68,7 @@ public sealed class Quiz: IQuizStatusProvider, IDisposable
     {
         TimeLimitInSeconds = timeLimitInSeconds;
         QuestionsCount = questionsCount;
+        SessionId = Guid.NewGuid().ToString();
 
         _questionSetProvider = questionSetProvider;
         _modelRepository = modelRepository;
@@ -148,19 +151,17 @@ public sealed class Quiz: IQuizStatusProvider, IDisposable
 
     private void RecordResult()
     {
-        if (User is not null)
-        {
-            _modelRepository?.Insert(
-                new QuizResult
-                {
-                    TimeStamp = DateTime.UtcNow, 
-                    UserId = User.Id,
-                    RightQuestionsCount = QuestionsRightCount, 
-                    TotalQuestionsCount = QuestionsCount,
-                    SecondsTaken = TimeTakenInSeconds, 
-                    MaxSeconds = TimeLimitInSeconds
-                });
-        }
+        _modelRepository?.Insert(
+            new QuizResult
+            {
+                TimeStamp = DateTime.UtcNow, 
+                UserId = User?.Id,
+                SessionId = SessionId,
+                RightQuestionsCount = QuestionsRightCount, 
+                TotalQuestionsCount = QuestionsCount,
+                SecondsTaken = TimeTakenInSeconds, 
+                MaxSeconds = TimeLimitInSeconds
+            });
     }
 
     public void Dispose()

--- a/ScrumTrainer/Components/QuizViewer.razor
+++ b/ScrumTrainer/Components/QuizViewer.razor
@@ -20,7 +20,7 @@
         }
         else
         {  
-            <p><strong>Warning: </strong>You are using this quiz as an anonymous user. <strong>Your quiz's result won't be recorded.</strong></p>
+            <p><strong>Note: </strong>You are using this quiz as an anonymous user. Your quiz's result will be recorded anonymously for administration purposes.</p>
         }
     </div>
 

--- a/ScrumTrainer/Data/Migrations/20260129095424_AddSessionIdAndNullableUserId.Designer.cs
+++ b/ScrumTrainer/Data/Migrations/20260129095424_AddSessionIdAndNullableUserId.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ScrumTrainer.Data;
 
@@ -10,9 +11,11 @@ using ScrumTrainer.Data;
 namespace ScrumTrainer.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260129095424_AddSessionIdAndNullableUserId")]
+    partial class AddSessionIdAndNullableUserId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.22");

--- a/ScrumTrainer/Data/Migrations/20260129095424_AddSessionIdAndNullableUserId.cs
+++ b/ScrumTrainer/Data/Migrations/20260129095424_AddSessionIdAndNullableUserId.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ScrumTrainer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSessionIdAndNullableUserId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_QuizResults_AspNetUsers_UserId",
+                table: "QuizResults");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UserId",
+                table: "QuizResults",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AddColumn<string>(
+                name: "SessionId",
+                table: "QuizResults",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_QuizResults_AspNetUsers_UserId",
+                table: "QuizResults",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_QuizResults_AspNetUsers_UserId",
+                table: "QuizResults");
+
+            migrationBuilder.DropColumn(
+                name: "SessionId",
+                table: "QuizResults");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UserId",
+                table: "QuizResults",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_QuizResults_AspNetUsers_UserId",
+                table: "QuizResults",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/ScrumTrainer/Models/QuizResult.cs
+++ b/ScrumTrainer/Models/QuizResult.cs
@@ -7,8 +7,9 @@ public record QuizResult
 {
     public int Id { get; set; }
     public DateTime TimeStamp { get; set; }
-    public string UserId { get; set; } = null!;
-    public ApplicationUser User { get; set; } = null!;
+    public string? UserId { get; set; }
+    public ApplicationUser? User { get; set; }
+    public string SessionId { get; set; } = null!;
     public int RightQuestionsCount { get; set; }
     public int TotalQuestionsCount { get; set; }
     public int SecondsTaken { get; set; }

--- a/ScrumTrainerTests/QuizTests.cs
+++ b/ScrumTrainerTests/QuizTests.cs
@@ -489,7 +489,7 @@ public class QuizTests
     public class Persistence
     {
         [Fact]
-        public void QuizHasNotUser_AfterFinish_NoResultRecorded()
+        public void QuizHasNotUser_AfterFinish_ResultRecordedWithSessionId()
         {
             var testModelRepository = new TestModelRepository<QuizResult>();
 
@@ -497,7 +497,72 @@ public class QuizTests
             quiz.StartQuiz();
             quiz.FinishQuiz();
 
-            testModelRepository.ModelSet.Should().BeEmpty();
+            testModelRepository.ModelSet.Should().HaveCount(1);
+            testModelRepository.ModelSet.First().UserId.Should().BeNull();
+            testModelRepository.ModelSet.First().SessionId.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void AnonymousUser_FinishesQuiz_ResultSavedAnonymouslyWithSessionId()
+        {
+            // Given: An anonymous user (no User assigned to quiz)
+            var testModelRepository = new TestModelRepository<QuizResult>();
+            using var quiz = new Quiz(3, 10, CreateQuestionSetProvider(), testModelRepository);
+            var sessionId = quiz.SessionId;
+
+            // When: User starts and finishes the quiz
+            quiz.StartQuiz();
+            foreach (var question in quiz.Questions)
+            {
+                question.SelectSingleAnswer(0);
+            }
+            quiz.FinishQuiz();
+
+            // Then: Result is saved anonymously with session tracking
+            var savedResult = testModelRepository.ModelSet.Should().HaveCount(1).And.Subject.First();
+            
+            // Verify anonymous tracking
+            savedResult.UserId.Should().BeNull("User should be null for anonymous results");
+            savedResult.SessionId.Should().Be(sessionId, "Session ID should match the quiz's session ID");
+            savedResult.SessionId.Should().NotBeEmpty("Session ID should not be empty");
+            Guid.TryParse(savedResult.SessionId, out _).Should().BeTrue("Session ID should be a valid GUID");
+
+            // Verify quiz results are properly recorded
+            savedResult.TimeStamp.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
+            savedResult.RightQuestionsCount.Should().Be(quiz.QuestionsRightCount);
+            savedResult.TotalQuestionsCount.Should().Be(3);
+            savedResult.SecondsTaken.Should().Be(quiz.TimeTakenInSeconds);
+            savedResult.MaxSeconds.Should().Be(10);
+        }
+
+        [Fact]
+        public void MultipleAnonymousAttempts_EachHasUniqueSessionId()
+        {
+            // Given: Two separate quiz attempts without user authentication
+            var testModelRepository = new TestModelRepository<QuizResult>();
+
+            // First attempt
+            using var quiz1 = new Quiz(3, 10, CreateQuestionSetProvider(), testModelRepository);
+            var sessionId1 = quiz1.SessionId;
+            quiz1.StartQuiz();
+            quiz1.FinishQuiz();
+
+            // Second attempt
+            using var quiz2 = new Quiz(3, 10, CreateQuestionSetProvider(), testModelRepository);
+            var sessionId2 = quiz2.SessionId;
+            quiz2.StartQuiz();
+            quiz2.FinishQuiz();
+
+            // Then: Both results are stored with different session IDs
+            testModelRepository.ModelSet.Should().HaveCount(2);
+            
+            var results = testModelRepository.ModelSet.OrderBy(r => r.TimeStamp).ToList();
+            results[0].SessionId.Should().Be(sessionId1);
+            results[1].SessionId.Should().Be(sessionId2);
+            results[0].SessionId.Should().NotBe(results[1].SessionId, "Each anonymous attempt should have a unique session ID");
+            
+            // Both should have null users
+            results.Should().AllSatisfy(r => r.UserId.Should().BeNull());
         }
 
         [Fact]


### PR DESCRIPTION
Before this change, anonymous quiz results were not stored, therefore usage statistics can be only made from registered users.

After this change, results of anonymous users are also stored in the database.